### PR TITLE
Properly honor downchroma flag

### DIFF
--- a/xClean.py
+++ b/xClean.py
@@ -193,7 +193,7 @@ def xClean(clip: vs.VideoNode, chroma: str = "nnedi3", sharp: float = 9.5, rn: f
         chroma = "none"
         conv = False
     dochroma = chroma != "none" or samp == "RGB"
-    downchroma = downchroma or False if chroma == "reconstructor" else True
+    downchroma = downchroma if downchroma is not None else False if chroma == "reconstructor" else True
 
     gpucuda = gpucuda if gpucuda != None else gpuid
     bd = clip.format.bits_per_sample


### PR DESCRIPTION
Properly handle downchroma flag set by the user, in the previous implementation the or would defeat a False when chroma wasn't "reconstructor"