### PR TITLE
use BM3Dv2 instead of BM3D

### DIFF
--- a/xClean.py
+++ b/xClean.py
@@ -419,9 +419,9 @@ def BM3D(clip: vs.VideoNode, ref: Optional[vs.VideoNode], sigma: float, gpuid: i
     chroma = clip.format.color_family==vs.YUV
     icalc = clip.format.bits_per_sample < 32
     if gpuid >= 0:
-        clean = core.bm3dcuda_rtc.BM3D(clip, ref, chroma=chroma, sigma=sigma, device_id=gpuid, fast=bm3d_fast, radius=radius, block_step=block_step, bm_range=bm_range, ps_range=ps_range)
+        clean = core.bm3dcuda_rtc.BM3Dv2(clip, ref, sigma=sigma, block_step=block_step, bm_range=bm_range, radius=radius, ps_range=ps_range, chroma=chroma, device_id=gpuid, fast=bm3d_fast)
     else:
-        clean = core.bm3dcpu.BM3D(clip, ref, chroma=chroma, sigma=sigma, block_step=block_step, bm_range=bm_range, ps_range=ps_range, radius=radius)
+        clean = core.bm3dcpu.BM3Dv2(clip, ref, sigma=sigma, block_step=block_step, bm_range=bm_range, radius=radius, ps_range=ps_range, chroma=chroma)
     clean = clean.bm3d.VAggregate(sample=0 if icalc else 1, radius=radius) if radius > 0 else clean
     return clean
 


### PR DESCRIPTION
This PR changes the BM3D backend from v1 to v2. This should solve the memory leak on linux reported in #10. The exposed API and parameters seems to be the same. It should be a simple drop-in replacement.

One note: I see that ps_num parameter is not exposed by xClean, is there a reason? Maybe it can be added in this PR if necessary.